### PR TITLE
chore: remove symfony_mailer patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,19 +27,12 @@
     "drupal/reroute_email": "^2.2",
     "drupal/schema_metatag": "^3.0",
     "drupal/svg_image": "^3.0",
-    "drupal/symfony_mailer": "^1.2",
+    "drupal/symfony_mailer": "^1.4",
     "drupal/token": "^1.12",
     "drupal/twig_field_value": "^2.0",
     "drupal/twig_tweak": "^3.2",
     "drupal/twig_vardumper": "^3.1",
     "drupal/upgrade_status": "^4.0",
     "drupal/webp": "^1.0@RC"
-  },
-  "extra": {
-    "patches": {
-      "drupal/symfony_mailer": {
-        "Drupal 10.1.0 new aggregation breaks InlineCssEmailAdjuster - https://www.drupal.org/project/symfony_mailer/issues/3371042#comment-15185259": "https://www.drupal.org/files/issues/2023-08-09/symfony_mailer_3371042_temporary_fix_1.patch"
-      }
-    }
   }
 }


### PR DESCRIPTION
Symfony mailer 1.4 includes the fix from the patch regarding Drupal 10.1 compatibility https://www.drupal.org/project/symfony_mailer/issues/3371042#comment-15185259